### PR TITLE
Provide the full details of 'data' when rendering fails.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-
+<<<<<<< HEAD
  * Documented how to use `render` as a transform stream.
 
 1.2.0 / 2014-10-09
@@ -25,7 +25,8 @@
 1.0.2 / 2014-08-14
 ==================
 
-  * 'retries' option is now documented (Mark Stosberg)
+  * 'retries' option is now documented (Mark Stosberg) 
+  * Provide complete request details when rendering fails. (Mark Stosberg)
   * Add "Troubleshooting" and "See Also" sections to README.md (Mark Stosberg)
   * Add HISTORY.md file (Mark Stosberg)
   * default value of 'tmp' is now documented (Mark Stosberg)

--- a/index.js
+++ b/index.js
@@ -266,7 +266,7 @@ var create = function(opts) {
     delete queued[data.id];
     if (!data.success) {
       fs.unlink(data.filename, noop);
-      return proxy.destroy(new Error('Render failed ('+data.tries+' tries)'));
+      return proxy.destroy(new Error('Render failed ('+data.tries+' tries) Request details: '+JSON.stringify(data)));
     }
 
     eos(proxy, { writable: false }, function() {


### PR DESCRIPTION
Enabling 'debug' is not sufficient, because of the async nature of things. The
 adjacent 'debug' line is not necessarily the one that corresponds to the
failed render.

When rendering fails, providing the related URL and other details are critical
to understanding what when wrong, so they are always provided now.