### PR TITLE
Fix hardcoded timeout value affecting renders taking longer than 10 seconds, but less then `timeout`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,8 +208,6 @@ var create = function(opts) {
 
   opts = xtend(defaultOpts,opts);
 
-  var tmp     = opts.tmp;
-
   var worker = pool(opts);
   var queued = {};
 
@@ -221,7 +219,7 @@ var create = function(opts) {
     if (!data.success && data.tries < opts.retries) {
       fs.unlink(data.filename, noop);
       data.tries++;
-      data.filename = path.join(tmp, hat()) + '.' + data.format;
+      data.filename = _getTmpFile(opts.tmp,data.format);
       data.sent = Date.now();
       return worker.write(data);
     }
@@ -238,15 +236,17 @@ var create = function(opts) {
   });
 
   var mkdir = thunky(function(cb) {
-    mkdirp(tmp, cb);
+    mkdirp(opts.tmp, cb);
   });
 
   var render = function(url, ropts) {
     ropts = xtend({format:opts.format, url:url, printMedia: opts.printMedia}, ropts);
-    ropts.filename = path.join(tmp, process.pid + '.' + hat()) + '.' + ropts.format;
+    ropts.filename = _getTmpFile(opts.tmp,ropts.format);
     ropts.id = hat();
     ropts.sent = Date.now();
     ropts.tries = 0;
+
+
     if (ropts.crop === true) ropts.crop = {top:0, left:0};
 
     var proxy = queued[ropts.id] = new Proxy();
@@ -271,5 +271,9 @@ var create = function(opts) {
 
   return render;
 };
+
+function _getTmpFile (tmpDir,format) {
+  return path.join(tmpDir, process.pid + '.' + hat()) + '.' + format;
+}
 
 module.exports = create;

--- a/index.js
+++ b/index.js
@@ -198,14 +198,21 @@ var pool = function(opts) {
 var create = function(opts) {
   if (!opts) opts = {};
 
-  opts.pool = opts.pool || 1;
-  opts.maxErrors = typeof opts.maxErrors === 'number' ? opts.maxErrors : 3;
-  opts.phantomFlags = opts.phantomFlags || [];
-  opts.timeout = opts.timeout !== false ? opts.timeout || 30000 : 0;
+  var defaultOpts = {
+    pool         : 1,
+    maxErrors    : 3,
+    phantomFlags : [],
+    timeout      : 30000,
+    retries      : 1,
+    tmp          : TMP,
+    format       : 'png',
+  };
 
-  var retries = opts.retries || 1;
-  var tmp = opts.tmp || TMP;
-  var format = opts.format || 'png';
+  opts = xtend(defaultOpts,opts);
+
+  var retries = opts.retries;
+  var tmp     = opts.tmp;
+  var format  = opts.format;
 
   var worker = pool(opts);
   var queued = {};

--- a/index.js
+++ b/index.js
@@ -240,7 +240,12 @@ var create = function(opts) {
   });
 
   var render = function(url, ropts) {
-    ropts = xtend({format:opts.format, url:url, printMedia: opts.printMedia}, ropts);
+    ropts = xtend({
+      url        : url,
+      format     : opts.format,
+      printMedia : opts.printMedia,
+      expects    : opts.expects,
+    }, ropts);
     ropts.filename = _getTmpFile(opts.tmp,ropts.format);
     ropts.id = hat();
     ropts.sent = Date.now();

--- a/index.js
+++ b/index.js
@@ -196,8 +196,6 @@ var pool = function(opts) {
 };
 
 var create = function(opts) {
-  if (!opts) opts = {};
-
   var defaultOpts = {
     pool         : 1,
     maxErrors    : 3,

--- a/index.js
+++ b/index.js
@@ -210,7 +210,6 @@ var create = function(opts) {
 
   opts = xtend(defaultOpts,opts);
 
-  var retries = opts.retries;
   var tmp     = opts.tmp;
   var format  = opts.format;
 
@@ -222,7 +221,7 @@ var create = function(opts) {
     var proxy = queued[data.id];
     if (!proxy) return;
 
-    if (!data.success && data.tries < retries) {
+    if (!data.success && data.tries < opts.retries) {
       fs.unlink(data.filename, noop);
       data.tries++;
       data.filename = path.join(tmp, hat()) + '.' + data.format;

--- a/index.js
+++ b/index.js
@@ -211,7 +211,6 @@ var create = function(opts) {
   opts = xtend(defaultOpts,opts);
 
   var tmp     = opts.tmp;
-  var format  = opts.format;
 
   var worker = pool(opts);
   var queued = {};
@@ -245,7 +244,7 @@ var create = function(opts) {
   });
 
   var render = function(url, ropts) {
-    ropts = xtend({format:format, url:url, printMedia: opts.printMedia}, ropts);
+    ropts = xtend({format:opts.format, url:url, printMedia: opts.printMedia}, ropts);
     ropts.filename = path.join(tmp, process.pid + '.' + hat()) + '.' + ropts.format;
     ropts.id = hat();
     ropts.sent = Date.now();

--- a/index.js
+++ b/index.js
@@ -245,6 +245,7 @@ var create = function(opts) {
       format     : opts.format,
       printMedia : opts.printMedia,
       expects    : opts.expects,
+      timeout    : opts.timeout
     }, ropts);
     ropts.filename = _getTmpFile(opts.tmp,ropts.format);
     ropts.id = hat();

--- a/phantom-process.js
+++ b/phantom-process.js
@@ -119,7 +119,7 @@ var loop = function() {
     var waitAndRender = function() {
       var timeout = setTimeout(function() {
         page.onAlert('webpage-error');
-      }, 10000);
+      }, line.timeout);
 
       var rendered = false;
       page.onAlert = function(msg) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -115,6 +115,18 @@ test('expects failure case, with options passed to phantom()', function(host, t)
   });
 });
 
+
+test('expects with window.renderable appearing before timeout should work', function (host,t) {
+  var render = phantom({expects:'lols', timeout:30000});
+  render(host +'/?slow-expects').pipe(concat(function(data) {
+    t.ok(data);
+    t.ok(data.length > 0);
+    t.end();
+  }));
+});
+
+
+
 test('timeout', function(host, t) {
   var render = phantom({timeout: 100});
   render(host + '/?timeout').on('error', function(err) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -81,7 +81,7 @@ test('print media', function(host, t) {
   }));
 });
 
-test('expects', function(host, t) {
+test('expects, with option passed to render()', function(host, t) {
   var render = phantom();
   render(host +'/?expects', {expects:'lols'}).pipe(concat(function(data) {
     t.ok(data);
@@ -90,9 +90,26 @@ test('expects', function(host, t) {
   }));
 });
 
-test('expects fail', function(host, t) {
+test('expects failure case, with option passed to render()', function(host, t) {
   var render = phantom();
   render(host +'/?expects', {expects:'meh'}).on('error', function(err) {
+    t.ok(err);
+    t.end();
+  });
+});
+
+test('expects, with option passed to phantom()', function(host, t) {
+  var render = phantom({expects:'lols'});
+  render(host +'/?expects').pipe(concat(function(data) {
+    t.ok(data);
+    t.ok(data.length > 0);
+    t.end();
+  }));
+});
+
+test('expects failure case, with options passed to phantom()', function(host, t) {
+  var render = phantom({expects:'meh'});
+  render(host +'/?expects').on('error', function(err) {
     t.ok(err);
     t.end();
   });

--- a/test/basic.js
+++ b/test/basic.js
@@ -117,7 +117,7 @@ test('expects failure case, with options passed to phantom()', function(host, t)
 
 
 test('expects with window.renderable appearing before timeout should work', function (host,t) {
-  var render = phantom({expects:'lols', timeout:30000});
+  var render = phantom({expects:'lols', timeout:3000});
   render(host +'/?slow-expects').pipe(concat(function(data) {
     t.ok(data);
     t.ok(data.length > 0);

--- a/test/helpers/test.js
+++ b/test/helpers/test.js
@@ -16,6 +16,11 @@ module.exports = function(msg, fn) {
 
       server = http.createServer(function(req, res) {
         req.connection.unref();
+        if (req.url.indexOf('slow-expects') > -1) {
+            // The expected test appears slow. Tests a bug where a hardcoded timeout was preventing slow renders from succeeding.
+            res.end('<html><head><script>window.renderable = false;setTimeout(function () { window.renderable="lols"; },12000);</script></head><body>hello</body></html>');
+          return;
+        }
         if (req.url.indexOf('expects') > -1) {
           res.end('<html><head><script>window.renderable = "lols"</script></head><body>hello</body></html>');
           return;

--- a/test/helpers/test.js
+++ b/test/helpers/test.js
@@ -17,7 +17,7 @@ module.exports = function(msg, fn) {
       server = http.createServer(function(req, res) {
         req.connection.unref();
         if (req.url.indexOf('expects') > -1) {
-          res.end('<html><body>hello</body><script>window.renderable = "lols"</script></body></html>');
+          res.end('<html><head><script>window.renderable = "lols"</script></head><body>hello</body></html>');
           return;
         }
         if (req.url.indexOf('timeout') > -1) {

--- a/test/helpers/test.js
+++ b/test/helpers/test.js
@@ -18,7 +18,7 @@ module.exports = function(msg, fn) {
         req.connection.unref();
         if (req.url.indexOf('slow-expects') > -1) {
             // The expected test appears slow. Tests a bug where a hardcoded timeout was preventing slow renders from succeeding.
-            res.end('<html><head><script>window.renderable = false;setTimeout(function () { window.renderable="lols"; },12000);</script></head><body>hello</body></html>');
+            res.end('<html><head><script>window.renderable = false;setTimeout(function () { window.renderable="lols"; },2000);</script></head><body>hello</body></html>');
           return;
         }
         if (req.url.indexOf('expects') > -1) {


### PR DESCRIPTION
There are additional commits here as this work built on other work:

 * I also ended up fixing a bug that I found in-process which is that `expects` is documented as something that can be passed to `phantom` as well as `render`, but that wasn't actually working. I added new test coverage to illustrate that.
* That detour in turn built on some other clean-up work I did, including addressing an issue where the tmp file names weren't been generated consistently. In one place they included in the PID, but not in the other, now they consistently include the PID.
* The changes above built on the work to improve the handling options in general, so those commits are included. 
* New test coverage for the longer-than-10-seconds render issue is also included. 

The fix includes using the same `timeout` option for the render timeout as well as the general phantom timeout. This is simpler than having two timeout values and might well be sufficient, so it's try it out. 

See the commit messages for more detail. I tried to make smaller commits with clear messages to you could see the detail of what was going on. I do see some typos in my commit messages where I meant "simplify" but typed "simply" instead. 