### PR TITLE
Make stderr from the child process available, in case it's useful for debugging.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 
  * Documented how to use `render` as a transform stream.
+ * When '--debug=true' is used as a phantomFlag, STDERR of the Phantom process is now
+   piped to the parent process STDERR adding a '[phantom stderr] ' prefix so that you can tell
+   it apart. (Mark Stosberg)
 
 1.2.0 / 2014-10-09
 ==================

--- a/index.js
+++ b/index.js
@@ -88,6 +88,12 @@ var spawn = function(opts) {
   child.stdout.pipe(debugStream('phantom (%s) stdout', child.pid)).pipe(output);
   input.pipe(debugStream('phantom (%s) stdin', child.pid)).pipe(child.stdin);
 
+  // Phantom may print to STDERR if the --debug flag is used.
+  // Pass through Phantom's STDERR to our own, while adding a prefix so we can tell them apart.
+  child.stderr.on('data', function (data) {
+    console.error("[phantom stderr] "+data);
+  });
+
   var onerror = once(function() {
     child.kill();
   });


### PR DESCRIPTION
Normally nothing is printed here.