### PR TITLE
add support for phantom console.log messages getting dumped to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ var render = phantom({
   maxErrors   : 3,           // Number errors phantom process is allowed to throw before killing it. Defaults to 3.
   expects     : 'something', // No default. Do not render until window.renderable is set to 'something'
   retries     : 1,           // How many times to try a render before giving up. Defaults to 1.
-  phantomFlags: ['--ignore-ssl-errors=true'] // Defaults to []. Command line flags passed to phantomjs 
+  phantomFlags: ['--ignore-ssl-errors=true'] // Defaults to []. Command line flags passed to phantomjs
   maxRenders  : 20,          // How many renders can a phantom process make before being restarted. Defaults to 20
-
+  phantomConsole : false     // Default to false; enable if you want console.log messages inside phantom to get dumped to stdout
 });
 ```
 
@@ -96,7 +96,7 @@ render('http://google.com')
 ## Deferred render
 
 If you need your page to do something before phantom renders it you just need to immediately set
-`window.renderable` to false. If that is set when the page is opened the module will wait for 
+`window.renderable` to false. If that is set when the page is opened the module will wait for
 `window.renderable` to be set to true and when this happens the render will occur.
 
 Here is an example to illustrate it better.

--- a/index.js
+++ b/index.js
@@ -298,6 +298,8 @@ var create = function(opts) {
       ropts.tries = 0;
       if (ropts.crop === true) ropts.crop = {top:0, left:0};
 
+      ropts.phantomConsole = opts.phantomConsole || false;
+
       mkdir(function(err) {
         if (err) return proxy.destroy(err);
         ropts.tries++;

--- a/phantom-process.js
+++ b/phantom-process.js
@@ -73,6 +73,12 @@ var loop = function() {
 
   if (!page) page = webpage.create();
 
+  if (line.phantomConsole === true) {
+    page.onConsoleMessage = function (msg) {
+      console.log('\tconsole: ' + msg);
+    };
+  }
+
   if (line.maxRenders) maxRenders = line.maxRenders;
   page.viewportSize = {
     width: line.width || 1280,


### PR DESCRIPTION
This adds support for passing PhantomJS `console.log` output through to `stdout` -- very useful for debugging, otherwise all page output is muted.