### PR TITLE
Added render attribute to be passed through to phantomjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ var render = phantom({
   tmp         : '/tmp',      // Set the tmp where tmp data is stored when communicating with the phantom process.
                              //   Defaults to /tmp if it exists, or os.tmpDir()
   format      : 'jpeg',      // The default output format. Defaults to png
+  quality     : 100,         // The default image quality. Defaults to 100. Only relevant for jpeg format.
   width       : 1280,        // Changes the width size. Defaults to 1280
   height      : 800,         // Changes the height size. Defaults to 960
   paperFormat : 'A4',        // Defaults to A4. Also supported: 'A3', 'A4', 'A5', 'Legal', 'Letter', 'Tabloid'.
@@ -66,7 +67,7 @@ var render = phantom({
 Or override the options for each render stream
 
 ``` js
-render(myUrl, {format:'jpeg', width: 1280, height: 960}).pipe(...)
+render(myUrl, {format:'jpeg', quality: 100, width: 1280, height: 960}).pipe(...)
 ```
 
 ## Supported output formats

--- a/index.js
+++ b/index.js
@@ -237,6 +237,7 @@ var create = function(opts) {
     retries      : 1,
     tmp          : TMP,
     format       : 'png',
+    quality       : 100
   };
 
   opts = xtend(defaultOpts,opts);
@@ -244,6 +245,7 @@ var create = function(opts) {
   var retries = opts.retries;
   var tmp     = opts.tmp;
   var format  = opts.format;
+  var quality = opts.quality;
 
   var worker = pool(opts);
   var server = serve();
@@ -288,7 +290,7 @@ var create = function(opts) {
     var proxy = queued[id] = duplexify();
 
     var initialize = function(url) {
-      ropts = xtend({format:format, url:url, printMedia: opts.printMedia}, ropts);
+      ropts = xtend({format:format, quality:quality, url:url, printMedia: opts.printMedia}, ropts);
       ropts.maxRenders = opts.maxRenders;
       ropts.filename = path.join(tmp, process.pid + '.' + hat()) + '.' + ropts.format;
       ropts.id = id;

--- a/phantom-process.js
+++ b/phantom-process.js
@@ -128,7 +128,7 @@ var loop = function() {
     var render = function() {
       setTimeout(function() {
         if (line.printMedia) forcePrintMedia();
-        page.render(line.filename, {format:line.format || 'png'});
+        page.render(line.filename, {format:line.format || 'png', quality:line.quality || 100});
         page = null;
         line.success = true;
         console.log(JSON.stringify(line));


### PR DESCRIPTION
As per [http://phantomjs.org/api/webpage/method/render.html]() 

Add support for quality render attribute.

No test for format, so have not extended for quality.