### PR TITLE
Trim trailing spaces

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -40,8 +40,8 @@
   * default value of 'tmp' is now documented (Mark Stosberg)
   * `maxErrors` option is documented. The option is used to limit how many phantom process errors
      are tolerated befor the process is killed.
-  * `maxRenders` option is addeded. It is the number of options that a phantom process can make before 
-     it will be restarted. Defaults to 20. 
+  * `maxRenders` option is addeded. It is the number of options that a phantom process can make before
+     it will be restarted. Defaults to 20.
 
 1.0.1 / 2014-06-19
 ==================
@@ -62,12 +62,12 @@
   * Kill phantom after 3 errors. New `maxErrors` option is added, but not yet documented.
 
 0.8.7 / 2014-06-19
-================== 
+==================
 
   * Forward printMedia option to phantomProcess
 
 0.8.6 / 2014-06-18
-================== 
+==================
 
   * Do not parse JSON strictly.
 
@@ -76,7 +76,7 @@
 
   * Bump ldjson-stream version requirement
   * Added support for passing command line options to phanton (Mark Stosberg, Ben Dalton)
-  
+
 0.8.4 / 2014-06-17
 ==================
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ var render = phantom({
   maxErrors   : 3,           // Number errors phantom process is allowed to throw before killing it. Defaults to 3.
   expects     : 'something', // No default. Do not render until window.renderable is set to 'something'
   retries     : 1,           // How many times to try a render before giving up. Defaults to 1.
-  phantomFlags: ['--ignore-ssl-errors=true'] // Defaults to []. Command line flags passed to phantomjs 
+  phantomFlags: ['--ignore-ssl-errors=true'] // Defaults to []. Command line flags passed to phantomjs
   maxRenders  : 20,          // How many renders can a phantom process make before being restarted. Defaults to 20
 
   injectJs    : ['./includes/my-polyfill.js'] // Array of paths to polyfill components or external scripts that will be injected when the page is initialized
@@ -97,7 +97,7 @@ render('http://google.com')
 ## Deferred render
 
 If you need your page to do something before phantom renders it you just need to immediately set
-`window.renderable` to false. If that is set when the page is opened the module will wait for 
+`window.renderable` to false. If that is set when the page is opened the module will wait for
 `window.renderable` to be set to true and when this happens the render will occur.
 
 Here is an example to illustrate it better.


### PR DESCRIPTION
Two (markdown) files have trailing spaces, making it harder to simply update and commit.