### PR TITLE
Provide full request details when rendering fails (rebased)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+
+ * Provide complete request details when rendering fails. (Mark Stosberg)
+
 1.5.0 / 2015-01-28
 ==================
 
@@ -40,7 +43,6 @@
 ==================
 
   * 'retries' option is now documented (Mark Stosberg) 
-  * Provide complete request details when rendering fails. (Mark Stosberg)
   * Add "Troubleshooting" and "See Also" sections to README.md (Mark Stosberg)
   * Add HISTORY.md file (Mark Stosberg)
   * default value of 'tmp' is now documented (Mark Stosberg)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+1.5.0 / 2015-01-28
+==================
+
+ * New quality option for specifying JPEG image quality. Defaults to 100.
+
 1.4.0 / 2014-11-21
 ==================
 
@@ -34,7 +39,8 @@
 1.0.2 / 2014-08-14
 ==================
 
-  * 'retries' option is now documented (Mark Stosberg)
+  * 'retries' option is now documented (Mark Stosberg) 
+  * Provide complete request details when rendering fails. (Mark Stosberg)
   * Add "Troubleshooting" and "See Also" sections to README.md (Mark Stosberg)
   * Add HISTORY.md file (Mark Stosberg)
   * default value of 'tmp' is now documented (Mark Stosberg)

--- a/index.js
+++ b/index.js
@@ -266,7 +266,7 @@ var create = function(opts) {
     delete queued[data.id];
     if (!data.success) {
       fs.unlink(data.filename, noop);
-      return proxy.destroy(new Error('Render failed ('+data.tries+' tries)'));
+      return proxy.destroy(new Error('Render failed ('+data.tries+' tries) Request details: '+JSON.stringify(data)));
     }
 
     eos(proxy, { writable: false }, function() {


### PR DESCRIPTION
This is the same PR as before, just rebased.

The only piece I needed to merge manually was in the history file, so the code changes
should be just as before.