### PR TITLE
Start making child's STDERR available when debugging is enabled.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 
+1.6.0 / 2015-01-29
+==================
+
  * Provide complete request details when rendering fails. (Mark Stosberg)
+ * Bug fix: "Render failed" no longer fails due to hardcoded internal timeout
+   value when rendering takes longer than 10 seconds and 'timeout' value is
+   set sufficiently high (#43, fixed by Mark Stosberg)
 
 1.5.0 / 2015-01-28
 ==================

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 
+ * When '--debug=true' is used as a phantomFlag and
+   'DEBUG=phantom-render-stream' is set in the environment, 
+   STDERR of the Phantom process is now piped to the parent process STDERR
+   and labeled as `stderr` so that you can tell it apart from `stdout`. (Mark Stosberg)
+
 1.6.0 / 2015-01-29
 ==================
 

--- a/index.js
+++ b/index.js
@@ -86,6 +86,7 @@ var spawn = function(opts) {
   var output = ldjson.parse({strict: false});
 
   child.stdout.pipe(debugStream('phantom (%s) stdout', child.pid)).pipe(output);
+  child.stderr.pipe(debugStream('phantom (%s) stderr', child.pid)).pipe(process.stderr);
   input.pipe(debugStream('phantom (%s) stdin', child.pid)).pipe(child.stdin);
 
   var onerror = once(function() {


### PR DESCRIPTION
This pull request supercedes #61.

  As @sorribas noted, using debugStream is cleaner and more consistent here.

I tested the patch by modifying `example.js` to set 'phantomFlags' with `--debug=true`
and also setting `DEBUG=phantom-render-stream` in the environment.