### PR TITLE
When `DEBUG=phantom-render-stream` is set, we now also provide the console.log output from the Phantom process

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,10 @@
    STDERR of the Phantom process is now piped to the parent process STDERR
    and labeled as `stderr` so that you can tell it apart from `stdout`. (Mark Stosberg)
 
+ * When `DEBUG=phantom-render-stream` is set, we now also provide the console.log output
+   from the Phantom process (Davis Ford and Mark Stosberg)
+
+
 1.6.0 / 2015-01-29
 ==================
 

--- a/phantom-process.js
+++ b/phantom-process.js
@@ -5,6 +5,15 @@ var system = require('system');
 
 var page = webpage.create();
 
+// If the parent set DEBUG=phantom-render-stream in the environment,
+// it will be passed through here and we'll send phantom's console.log messages back to STDOUT
+if (system.env.DEBUG && system.env.DEBUG.match(/phantom-render-stream/)) {
+  page.onConsoleMessage = function (msg) {
+    console.log('console.log: ' + msg);
+  };
+}
+
+
 var forcePrintMedia = function() {
   page.evaluate(function() {
     var findPrintMedia = function() {

--- a/phantom-process.js
+++ b/phantom-process.js
@@ -1,6 +1,5 @@
 // Code to be run by PhantomJS.
 // The docs for these modules are here: http://phantomjs.org/api/
-// Note that the 'fs' module here has a different API than the one in node.js core.
 var webpage = require('webpage');
 var system = require('system');
 


### PR DESCRIPTION
This is a follow-up to #65. The approach has been simplified a bit by not
adding another flag, but using the `DEBUG=phantom-render-stream` option already
available.

It was tested using 'example.js', testing with and without the DEBUG flag set.