### PR TITLE
Add new ./debug.js as a quick tool to help debug render failures.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,10 @@
    STDERR of the Phantom process is now piped to the parent process STDERR
    and labeled as `stderr` so that you can tell it apart from `stdout`. (Mark Stosberg)
 
+ * When `DEBUG=phantom-render-stream` is set, we now also provide the console.log output
+   from the Phantom process (Davis Ford and Mark Stosberg)
+
+
 1.6.0 / 2015-01-29
 ==================
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,14 +1,18 @@
 
- * When '--debug=true' is used as a phantomFlag and
-   'DEBUG=phantom-render-stream' is set in the environment, 
-   STDERR of the Phantom process is now piped to the parent process STDERR
-   and labeled as `stderr` so that you can tell it apart from `stdout`. (Mark Stosberg)
 
  * When `DEBUG=phantom-render-stream` is set, we now also provide the console.log output
    from the Phantom process (Davis Ford and Mark Stosberg)
 
  * New ./debug.js tool has been added to help troubleshoot render failures. See
    Troubleshooting section in the README for details. (Mark Stosberg)
+
+1.7.0 / 2015-01-30
+==================
+
+ * When '--debug=true' is used as a phantomFlag and
+   'DEBUG=phantom-render-stream' is set in the environment,
+   STDERR of the Phantom process is now piped to the parent process STDERR
+   and labeled as `stderr` so that you can tell it apart from `stdout`. (Mark Stosberg)
 
 
 1.6.0 / 2015-01-29

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,9 @@
  * When `DEBUG=phantom-render-stream` is set, we now also provide the console.log output
    from the Phantom process (Davis Ford and Mark Stosberg)
 
+ * New ./debug.js tool has been added to help troubleshoot render failures. See
+   Troubleshooting section in the README for details. (Mark Stosberg)
+
 
 1.6.0 / 2015-01-29
 ==================

--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ render, it's likely a connection issue of some sort. If the URL uses SSL,
 adding `--ignore-ssl-errors=true` to phantomFlags may help. You also try adding
 `--debug=true` to the `phantomFlags` array.
 
+A simple script with debugging options enabled is included with the
+project to help you as well. To use it from the project directory, simply:
+
+    node ./debug.js http://your.url.to.debug
+
+Maximal debugging output will be provided. Check [the source](./debug.js) for more ideas.
 
 ## See Also
 

--- a/debug.js
+++ b/debug.js
@@ -1,0 +1,37 @@
+// This a minimal script you can use for debugging
+// It has debug options turned on for you.
+
+var urlToDebug = process.argv[2]; 
+if (!urlToDebug) {
+  console.error("Must pass url to debug: debug.js http://example.com");
+  process.exit(1);
+}
+
+process.env.DEBUG='phantom-render-stream';
+var phantom = require('./');
+var fs = require('fs');
+
+var render = phantom({
+  phantomFlags : ['--debug=true'],
+  // Try ignoring SSL errors to see if that helps
+  //phantomFlags : ['--debug=true','--ignore-ssl-errors=true'],
+
+  // Try a long timeout and see if that helps
+  //timeout: 1000000,
+});
+
+var outputStream = fs.createWriteStream('debug.png');
+
+var renderStream = render(urlToDebug);
+
+// Capturing the error event if your render stream is a good idea.
+renderStream.on('error', function (msg) {
+  console.log("ERROR: "+msg);
+});
+
+outputStream.on('finish', function () {
+  console.log("Done. Review debug.png");
+});
+
+renderStream.pipe(outputStream);
+

--- a/phantom-process.js
+++ b/phantom-process.js
@@ -5,6 +5,15 @@ var system = require('system');
 
 var page = webpage.create();
 
+// If the parent set DEBUG=phantom-render-stream in the environment,
+// it will be passed through here and we'll send phantom's console.log messages back to STDOUT
+if (system.env.DEBUG && system.env.DEBUG.match(/phantom-render-stream/)) {
+  page.onConsoleMessage = function (msg) {
+    console.log('console.log: ' + msg);
+  };
+}
+
+
 var forcePrintMedia = function() {
   page.evaluate(function() {
     var findPrintMedia = function() {

--- a/phantom-process.js
+++ b/phantom-process.js
@@ -1,6 +1,5 @@
 // Code to be run by PhantomJS.
 // The docs for these modules are here: http://phantomjs.org/api/
-// Note that the 'fs' module here has a different API than the one in node.js core.
 var webpage = require('webpage');
 var system = require('system');
 


### PR DESCRIPTION
See commit for details. This branch is forked from my other recent work
but could be rebased to standalone.