### PR TITLE
Allow the user to specify their own path to PhantomJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ var render = phantom({
   maxErrors   : 3,           // Number errors phantom process is allowed to throw before killing it. Defaults to 3.
   expects     : 'something', // No default. Do not render until window.renderable is set to 'something'
   retries     : 1,           // How many times to try a render before giving up. Defaults to 1.
+  phantomPath : 'phantomjs'  // Defaults to PhantomJS path provided by the phantomjs module.
   phantomFlags: ['--ignore-ssl-errors=true'] // Defaults to []. Command line flags passed to phantomjs
   maxRenders  : 500,          // How many renders can a phantom process make before being restarted. Defaults to 500
 

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ var serve = function() {
 
 var spawn = function(opts) {
   var phantomjsArgs = opts.phantomFlags.concat(path.join(__dirname, 'phantom-process.js'));
-  var child = proc.spawn(phantomjsPath, phantomjsArgs);
+  var child = proc.spawn(opts.phantomPath, phantomjsArgs);
   debug('phantom (%s) spawned', child.pid);
 
   var input = ldjson.serialize();
@@ -231,6 +231,7 @@ var create = function(opts) {
   var defaultOpts = {
     pool         : 1,
     maxErrors    : 3,
+    phantomPath  : phantomjsPath,
     phantomFlags : [],
     timeout      : 30000,
     retries      : 1,


### PR DESCRIPTION
It's a small change that can help people use PhantomJS 2 (#86) or whichever version they prefer, just by setting the path to PhantomJS just like any other setting.