### PR TITLE
Update references to phantomjs (installs PhantomJS 2)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,8 @@
+2.0.0
+==================
 
+ * Switched to PhantomJS 2: replaced the (now deprecated) `phantomjs` dependency
+   with `phantomjs-prebuilt` which installs PhantomJS 2.
  * When '--debug=true' is used as a phantomFlag and
    'DEBUG=phantom-render-stream' is set in the environment,
    STDERR of the Phantom process is now piped to the parent process STDERR

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 
  * When '--debug=true' is used as a phantomFlag and
-   'DEBUG=phantom-render-stream' is set in the environment, 
+   'DEBUG=phantom-render-stream' is set in the environment,
    STDERR of the Phantom process is now piped to the parent process STDERR
    and labeled as `stderr` so that you can tell it apart from `stdout`. (Mark Stosberg)
 
@@ -53,7 +53,7 @@
 1.0.2 / 2014-08-14
 ==================
 
-  * 'retries' option is now documented (Mark Stosberg) 
+  * 'retries' option is now documented (Mark Stosberg)
   * Add "Troubleshooting" and "See Also" sections to README.md (Mark Stosberg)
   * Add HISTORY.md file (Mark Stosberg)
   * default value of 'tmp' is now documented (Mark Stosberg)
@@ -142,7 +142,3 @@
 ===================
 
   * No formal documented history. See Github commits.
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ New requests are added to the pool member with the shortest queue length.
 
 ## Synopsis
 
-This module depends on the [phantomjs](https://www.npmjs.org/package/phantomjs) module, which will install
+This module depends on the [phantomjs-prebuilt](https://www.npmjs.org/package/phantomjs-prebuilt) module, which will install
 `phantomjs` for you if you don't already have it.
 
 ``` js

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ New requests are added to the pool member with the shortest queue length.
 ## Synopsis
 
 This module depends on the [phantomjs-prebuilt](https://www.npmjs.org/package/phantomjs-prebuilt) module, which will install
-`phantomjs` for you if you don't already have it.
+[PhantomJS](http://phantomjs.org/) for you if you don't already have it.
 
 ``` js
 var phantom = require('phantom-render-stream');
@@ -57,7 +57,7 @@ var render = phantom({
   maxErrors   : 3,           // Number errors phantom process is allowed to throw before killing it. Defaults to 3.
   expects     : 'something', // No default. Do not render until window.renderable is set to 'something'
   retries     : 1,           // How many times to try a render before giving up. Defaults to 1.
-  phantomFlags: ['--ignore-ssl-errors=true'] // Defaults to []. Command line flags passed to phantomjs
+  phantomFlags: ['--ignore-ssl-errors=true'] // Defaults to []. Command line flags passed to PhantomJS
   maxRenders  : 500,          // How many renders can a phantom process make before being restarted. Defaults to 500
 
   injectJs    : ['./includes/my-polyfill.js'] // Array of paths to polyfill components or external scripts that will be injected when the page is initialized
@@ -72,7 +72,7 @@ render(myUrl, {format:'jpeg', quality: 100, width: 1280, height: 960}).pipe(...)
 
 ## Supported output formats
 
-We support the output formats that [Phantom's render method](http://phantomjs.org/api/webpage/method/render.html)
+We support the output formats that [PhantomJS's render method](http://phantomjs.org/api/webpage/method/render.html)
 supports. At the time of this writing these are:
 
  * png

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ var os = require('os');
 var http = require('http');
 var debug = require('debug')('phantom-render-stream');
 var debugStream = require('debug-stream')(debug);
-var phantomjsPath = require('phantomjs').path;
+var phantomjsPath = require('phantomjs-prebuilt').path;
 
 var noop = function() {};
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ldjson-stream": "^1.1.0",
     "mkdirp": "^0.5.0",
     "once": "^1.3.0",
-    "phantomjs-prebuilt": "2.1.x",
+    "phantomjs-prebuilt": "^2.1.4",
     "thunky": "^0.1.0",
     "xtend": "^3.0.0",
     "duplexify": "~3.2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ldjson-stream": "^1.1.0",
     "mkdirp": "^0.5.0",
     "once": "^1.3.0",
-    "phantomjs": "2.1.x",
+    "phantomjs-prebuilt": "2.1.x",
     "thunky": "^0.1.0",
     "xtend": "^3.0.0",
     "duplexify": "~3.2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ldjson-stream": "^1.1.0",
     "mkdirp": "^0.5.0",
     "once": "^1.3.0",
-    "phantomjs": "1.9.x",
+    "phantomjs": "2.1.x",
     "thunky": "^0.1.0",
     "xtend": "^3.0.0",
     "duplexify": "~3.2.0",

--- a/test/helpers/test.js
+++ b/test/helpers/test.js
@@ -1,7 +1,7 @@
 var tape = require('tape');
 var http = require('http');
 var proc = require('child_process');
-var phantomjsPath = require('phantomjs').path;
+var phantomjsPath = require('phantomjs-prebuilt').path;
 
 var server;
 module.exports = function(msg, fn) {
@@ -10,7 +10,7 @@ module.exports = function(msg, fn) {
 
     proc.exec(phantomjsPath + ' --version', function(err) {
       if (err) {
-        t.fail('phantomjs module is not properly installed. Try re-installing it. Error was: '+err);
+        t.fail('phantomjs-prebuilt module is not properly installed. Try re-installing it. Error was: '+err);
         process.exit(1);
       }
 


### PR DESCRIPTION
This PR changes the name of package from `phantomjs` to `pantomjs-prebuilt` (following https://github.com/Medium/phantomjs/issues/447) and installs the latest `2.1.x` version, which installs PhantomJS 2.1.1. This closes https://github.com/e-conomic/phantom-render-stream/issues/86

By setting the version as `2.1.x`, I was just going with the current convention. Perhaps it could be more liberal i.e. `^2.1.2`.