### PR TITLE
Emit phantom logs - JS errors, console logs, timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,31 @@ For rendering, PhantomJS requires the `fontconfig` library, which may be missing
 
 ## Troubleshooting
 
-Some additional debugging output may be enabled by running your script with a
+Render stream emits "log" event with useful debug details:
+- JS errors on page
+- console.log's
+- page resource error
+- page resource timeou
+- expectation not met
+
+```javascript
+var render = phantom();
+
+render('http://somewhere.com')
+  .on('log', function(log) {
+    // {
+    //   type: 'error',
+    //   data: {
+    //     msg: 'ReferenceError: Can\'t find variable: a',
+    //     trace: [..]
+    // }
+  })
+  .pipe(res);
+```
+
+These logs are equivalents of phantom webpage hooks: onError, onConsoleMessage, onResourceError, onResourceTimeout.
+
+Finally, Some additional debugging output may be enabled by running your app with a
 `DEBUG` environment variable set as follows:
 
     DEBUG=phantom-render-stream  node ./your-script.js

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ var render = phantom();
 
 render('http://somewhere.com')
   .on('log', function(log) {
-    // {type: 'error', data: {msg: 'ReferenceError: Can\'t find variable: a', trace: [..]}
+    // {type: 'error', data: {msg: 'ReferenceError: Can\'t find variable: a', trace: [..]}}
   })
   .pipe(res);
 ```

--- a/README.md
+++ b/README.md
@@ -172,31 +172,19 @@ For rendering, PhantomJS requires the `fontconfig` library, which may be missing
 
 ## Troubleshooting
 
-Render stream emits "log" event with useful debug details:
-- JS errors on page
-- console.log's
-- page resource error
-- page resource timeou
-- expectation not met
+Render stream emits "log" event with useful debug details coming from onError (JS error), onConsoleMessage, onResourceError, onResourceTimeout webpage hooks.
 
 ```javascript
 var render = phantom();
 
 render('http://somewhere.com')
   .on('log', function(log) {
-    // {
-    //   type: 'error',
-    //   data: {
-    //     msg: 'ReferenceError: Can\'t find variable: a',
-    //     trace: [..]
-    // }
+    // {type: 'error', data: {msg: 'ReferenceError: Can\'t find variable: a', trace: [..]}
   })
   .pipe(res);
 ```
 
-These logs are equivalents of phantom webpage hooks: onError, onConsoleMessage, onResourceError, onResourceTimeout.
-
-Finally, Some additional debugging output may be enabled by running your app with a
+Also, some additional debugging output may be enabled by running your app with a
 `DEBUG` environment variable set as follows:
 
     DEBUG=phantom-render-stream  node ./your-script.js

--- a/index.js
+++ b/index.js
@@ -187,6 +187,8 @@ var pool = function(opts) {
     });
 
     worker.stream.on('data', function(data) {
+      if (!data.log) return dup.push(data);
+      
       if (!data.success) worker.errors++;
       else worker.errors = 0;
 
@@ -249,6 +251,8 @@ var create = function(opts) {
     var proxy = queued[data.id];
     if (!proxy) return;
 
+    if (data.log) return proxy.emit('log', data.log);
+  
     if (!data.success && data.tries < opts.retries) {
       fs.unlink(data.filename, noop);
       data.tries++;
@@ -260,7 +264,9 @@ var create = function(opts) {
     delete queued[data.id];
     if (!data.success) {
       fs.unlink(data.filename, noop);
-      return proxy.destroy(new Error('Render failed ('+data.tries+' tries) Request details: '+JSON.stringify(data)));
+      return proxy.destroy(new Error(
+        'Render failed (' + data.tries + ' tries) ' + 
+        'Request details: ' + JSON.stringify(data))); 
     }
 
     eos(proxy, { writable: false }, function() {

--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ var pool = function(opts) {
     });
 
     worker.stream.on('data', function(data) {
-      if (!data.log) return dup.push(data);
+      if (data.log) return dup.push(data);
       
       if (!data.success) worker.errors++;
       else worker.errors = 0;

--- a/phantom-process.js
+++ b/phantom-process.js
@@ -4,7 +4,61 @@
 var webpage = require('webpage');
 var system = require('system');
 
-var page = webpage.create();
+var page = createWebPage();
+
+function log (message) {
+  var json = JSON.stringify({
+    message: message
+  });
+
+  console.log(json);
+}
+
+function createWebPage () {
+  var page = webpage.create();
+
+  page.onConsoleMessage = function (msg, lineNum, sourceId) {
+    log({
+      type: 'consoleMessage',
+      data: {
+        msg: msg,
+        lineNum: lineNum,
+        sourceId: sourceId
+      }
+    });
+  };
+
+  page.onError = function (msg, trace) {
+    log({
+      type: 'error',
+      data: {
+        msg: msg,
+        trace: trace
+      }
+    });
+  };
+
+  page.onResourceError = function (resourceError) {
+    log({
+      type: 'resourceError',
+      data: {
+        resourceError: resourceError
+      }
+    });
+  };
+
+  page.onResourceTimeout = function(request) {
+    log({
+      type: 'resourceTimeout',
+      data: {
+        request: request
+      }
+    });
+  };
+
+  return page;
+}
+
 
 var forcePrintMedia = function() {
   page.evaluate(function() {
@@ -71,7 +125,7 @@ var loop = function() {
     return phantom.exit(1);
   }
 
-  if (!page) page = webpage.create();
+  if (!page) page = createWebPage();
 
   if (line.cookies && line.cookies.length > 0) {
     line.cookies.forEach(function (c) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -135,12 +135,8 @@ test('emits phantom logs - console', function(host, t) {
   var render = phantom();
   render(host + '/?log-console')
     .on('log', function(log) {
-      t.deepEqual(log, {
-        type: 'consoleMessage',
-        data: {
-          msg: 'useful log'
-        }
-      });
+      t.equal(log.type, 'consoleMessage');
+      t.equal(log.data.msg, 'useful log');
       t.end();
     });
 });
@@ -149,13 +145,9 @@ test('emits phantom logs - js errors', function(host, t) {
   var render = phantom();
   render(host + '/?log-error')
     .on('log', function(log) {
-      t.deepEqual(log, {
-        type: 'error',
-        data: {
-          msg: 'ReferenceError: Can\'t find variable: a',
-          trace: [ { file: host + '/?log-error', function: '', line: 1 } ]
-        }
-      });
+      t.equal(log.type, 'error');
+      t.equal(log.data.msg, 'ReferenceError: Can\'t find variable: a');
+      t.deepEqual(log.data.trace, [ { file: host + '/?log-error', function: '', line: 1 } ]);
       t.end();
     });
 });

--- a/test/basic.js
+++ b/test/basic.js
@@ -147,7 +147,7 @@ test('emits phantom logs - js errors', function(host, t) {
     .on('log', function(log) {
       t.equal(log.type, 'error');
       t.equal(log.data.msg, 'ReferenceError: Can\'t find variable: a');
-      t.deepEqual(log.data.trace, [ { file: host + '/?log-error', function: '', line: 1 } ]);
+      t.ok(log.data.trace);
       t.end();
     });
 });

--- a/test/basic.js
+++ b/test/basic.js
@@ -114,9 +114,8 @@ test('expects failure case, with options passed to phantom()', function(host, t)
   });
 });
 
-
 test('expects with window.renderable appearing before timeout should work', function (host,t) {
-  var render = phantom({expects:'lols', timeout:3000});
+  var render = phantom({expects:'lols', timeout:5000});
   render(host +'/?slow-expects').pipe(concat(function(data) {
     t.ok(data);
     t.ok(data.length > 0);
@@ -124,12 +123,39 @@ test('expects with window.renderable appearing before timeout should work', func
   }));
 });
 
-
-
 test('timeout', function(host, t) {
   var render = phantom({timeout: 100});
   render(host + '/?timeout').on('error', function(err) {
     t.ok(err);
     t.end();
   });
+});
+
+test('emits phantom logs - console', function(host, t) {
+  var render = phantom();
+  render(host + '/?log-console')
+    .on('log', function(log) {
+      t.deepEqual(log, {
+        type: 'consoleMessage',
+        data: {
+          msg: 'useful log'
+        }
+      });
+      t.end();
+    });
+});
+
+test('emits phantom logs - js errors', function(host, t) {
+  var render = phantom();
+  render(host + '/?log-error')
+    .on('log', function(log) {
+      t.deepEqual(log, {
+        type: 'error',
+        data: {
+          msg: 'ReferenceError: Can\'t find variable: a',
+          trace: [ { file: host + '/?log-error', function: '', line: 1 } ]
+        }
+      });
+      t.end();
+    });
 });

--- a/test/helpers/test.js
+++ b/test/helpers/test.js
@@ -28,6 +28,14 @@ module.exports = function(msg, fn) {
         if (req.url.indexOf('timeout') > -1) {
           return; // do nothing...
         }
+        if (req.url.indexOf('log-console') > -1) {
+          res.end('<html><head><script>console.log("useful log");</script></head><body>hello</body></html>');
+          return;
+        }
+        if (req.url.indexOf('log-error') > -1) {
+          res.end('<html><head><script>a.b=1;</script></head><body>hello</body></html>');
+          return;
+        }
         res.end('hello world\n');
       });
       server.listen(0, function() {


### PR DESCRIPTION
Currently we have no details if html conversion fails. Basically we have “Render pdf failed ..” with page url and phantom details. We need to see JS errors, timeouts, console logs happened during the render.

I've added handlers for related phantom page events (onConsoleMessage, onError etc) and emitting this logs as “log” event to output stream. So it's up to consumer to decide what to do with them. It’s not only for error handling, but for troubleshooting successful renders too, see new tape specs.

```
var render = phantom();
render(host).on(‘log’, function(log) {
   // store to logentries, etc
});
```

Also introduced page.log function for any custom logs (like scripts injected), and made sure this logs are not affecting worker.errors or other processing - they just emitted to output stream.

I think to add array of related logs as extra information in the error message - but that will go in a separate PR